### PR TITLE
Make pkg. version req. less strict

### DIFF
--- a/cmpInt.h
+++ b/cmpInt.h
@@ -84,7 +84,7 @@ Tcl_FreeInternalRep(Tcl_Obj *objPtr) {
  * The version of the tbcload package needed to load scripts compiled by this
  * version of the compiler.
  */
-#define TBCLOAD_VERSION "2.0"
+#define TBCLOAD_VERSION "2.0a0"
 
 /*
  * This macro includes code that emits and reads the location map for a

--- a/cmpWPkg.c
+++ b/cmpWPkg.c
@@ -113,12 +113,12 @@ static int RegisterVariable(Tcl_Interp* interp, const char* ns, const VarTable* 
 int Tclcompiler_Init(Tcl_Interp* interp)
 {
 #ifdef USE_TCL_STUBS
-    if (!Tcl_InitStubs(interp, TCL_VERSION, 1))
+    if (!Tcl_InitStubs(interp, TCL_VERSION, 0))
     {
         return TCL_ERROR;
     }
 #else
-    if (Tcl_PkgRequire(interp, "Tcl", TCL_VERSION, 1) == NULL)
+    if (Tcl_PkgRequire(interp, "Tcl", TCL_VERSION, 0) == NULL)
     {
         return TCL_ERROR;
     }


### PR DESCRIPTION
See tcltk-depot/tbcload#5. This does the same but for tclcompiler.

In addition, a patch has been applied to use the same TBCLOAD_VERSION as tbcload. If these don't match, the generated file header will fail to load the proper tbcload extension.